### PR TITLE
Move dialect package to software.amazon.dsql.hibernate.dialect

### DIFF
--- a/.github/workflows/java-hibernate-tests.yml
+++ b/.github/workflows/java-hibernate-tests.yml
@@ -55,7 +55,7 @@ jobs:
         mvn clean package
         mvn install:install-file \
           -Dfile=target/aws-dsql-hibernate-1.0.0.jar \
-          -DgroupId=com.amazon \
+          -DgroupId=software.amazon \
           -DartifactId=aws-dsql-hibernate \
           -Dversion=1.0.0 \
           -Dpackaging=jar

--- a/dialect/README.md
+++ b/dialect/README.md
@@ -32,9 +32,9 @@ implementation("com.amazon:aws-dsql-hibernate:1.0.0")
 ```
 
 With the AWS-DSQL-Hibernate JAR included in your Java application, the dialect can then be set in a few ways:
-- In a Hibernate.properties file: `hibernate.dialect=com.amazon.dsql.hibernate.dialect.AuroraDSQLDialect`
-- In persistence.xml: `<property name="hibernate.dialect" value="com.amazon.dsql.hibernate.dialect.AuroraDSQLDialect"/>`
-- In Spring application properties: `spring.jpa.properties.hibernate.dialect=com.amazon.dsql.hibernate.dialect.AuroraDSQLDialect`
+- In a Hibernate.properties file: `hibernate.dialect=software.amazon.dsql.hibernate.dialect.AuroraDSQLDialect`
+- In persistence.xml: `<property name="hibernate.dialect" value="software.amazon.dsql.hibernate.dialect.AuroraDSQLDialect"/>`
+- In Spring application properties: `spring.jpa.properties.hibernate.dialect=software.amazon.dsql.hibernate.dialect.AuroraDSQLDialect`
 - Programmatically using `StandardServiceRegistryBuilder`, the configuration API, or in a `SessionFactory`
 
 Hibernate will not automatically detect the DSQL dialect based on metadata, it must be explicitly specified or else

--- a/dialect/src/main/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialect.java
+++ b/dialect/src/main/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialect.java
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1
-package com.amazon.dsql.hibernate.dialect;
+package software.amazon.dsql.hibernate.dialect;
 
 import jakarta.persistence.TemporalType;
 import org.hibernate.LockMode;

--- a/dialect/src/test/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialectFunctionsTest.java
+++ b/dialect/src/test/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialectFunctionsTest.java
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1
-package com.amazon.dsql.hibernate.dialect;
+package software.amazon.dsql.hibernate.dialect;
 
 import org.hibernate.query.sqm.TemporalUnit;
 import org.hibernate.sql.ast.spi.SqlAppender;

--- a/dialect/src/test/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialectTest.java
+++ b/dialect/src/test/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialectTest.java
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1
-package com.amazon.dsql.hibernate.dialect;
+package software.amazon.dsql.hibernate.dialect;
 
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;

--- a/examples/pet-clinic-app/src/test/resources/application-test.properties
+++ b/examples/pet-clinic-app/src/test/resources/application-test.properties
@@ -1,5 +1,5 @@
 spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH
-spring.jpa.properties.hibernate.dialect=com.amazon.dsql.hibernate.dialect.AuroraDSQLDialect
+spring.jpa.properties.hibernate.dialect=software.amazon.dsql.hibernate.dialect.AuroraDSQLDialect
 
 app.datasource.url=jdbc:postgresql://test-hostname:5432/testdb
 app.datasource.username=test-user

--- a/examples/pet-clinic-app/src/test/resources/application.properties
+++ b/examples/pet-clinic-app/src/test/resources/application.properties
@@ -2,7 +2,7 @@ spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=password
-spring.jpa.database-platform=com.amazon.dsql.hibernate.dialect.AuroraDSQLDialect
+spring.jpa.database-platform=software.amazon.dsql.hibernate.dialect.AuroraDSQLDialect
 
 # Enable H2 console for debugging
 spring.h2.console.enabled=true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Moves the dialect package to software.amazon.dsql.hibernate.dialect, to be more aligned with other packages as com.amazon.* is not supposed to be used anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
