### PR TITLE
Fix flaky test DialectConfigurationPropertiesFileTest

### DIFF
--- a/dialect/build.gradle
+++ b/dialect/build.gradle
@@ -26,20 +26,24 @@ dependencies {
 
 }
 
-test {
+
+// This is separated to ensure isolation in the Dialect configuration tests
+tasks.register('configurationTests', Test) {
     useJUnitPlatform()
-    forkEvery = 0
-    maxParallelForks = 1
+    include '**/DialectConfiguration*Test.class'
+    forkEvery = 1  // Fork for each configuration test
     systemProperty 'RUN_INTEGRATION', System.getenv('RUN_INTEGRATION') ?: 'FALSE'
     systemProperty 'test.resources.dir', "${project.buildDir}/resources/test"
+}
 
-    // The configuration file tests break without this, because they conflict with cached properties
-    tasks.register('configTests', Test) {
-        filter {
-            includeTestsMatching "*.DialectConfiguration*Test"
-        }
-        forkEvery = 1
-    }
+test {
+    useJUnitPlatform()
+    systemProperty 'RUN_INTEGRATION', System.getenv('RUN_INTEGRATION') ?: 'FALSE'
+
+    // Exclude configuration tests from main test task, as they require isolation
+    exclude '**/DialectConfiguration*Test.class'
+
+    dependsOn configurationTests
 }
 
 java {

--- a/dialect/src/test/java/software/amazon/dsql/hibernate/dialect/integration/DialectConfigurationPropertiesFileTest.java
+++ b/dialect/src/test/java/software/amazon/dsql/hibernate/dialect/integration/DialectConfigurationPropertiesFileTest.java
@@ -9,6 +9,7 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Isolated;
 import software.amazon.dsql.hibernate.dialect.AuroraDSQLDialect;
 
 import java.io.File;
@@ -16,6 +17,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 @EnabledIfSystemProperty(named = "RUN_INTEGRATION", matches = "TRUE")
+@Isolated
 public class DialectConfigurationPropertiesFileTest {
 
     @Test


### PR DESCRIPTION
*Description of changes:*

Depending on test order, the configuration test from a hibernate.properties file would fail. This is because it wouldn't pick up the file if a configuration was triggered first. This change ensures the test runs in its own JVM, which makes it pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
