### PR TITLE
Use JDBC connector for IAM authentication

### DIFF
--- a/.github/workflows/java-hibernate-tests.yml
+++ b/.github/workflows/java-hibernate-tests.yml
@@ -68,3 +68,12 @@ jobs:
         mvn initialize
         mvn clean compile
         mvn test
+
+    - name: Run DSQL integration test
+      working-directory: ./examples/pet-clinic-app
+      env:
+        CLUSTER_ENDPOINT: ${{ secrets.HIBERNATE_DIALECT_INTEGRATION_CLUSTER_ENDPOINT }}
+        CLUSTER_USER: admin
+        RUN_INTEGRATION: "TRUE"
+      run: |
+        mvn test -Dtest=DsqlIntegrationTest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ maven-status/
 test-classes/
 target/
 **/.gradle
+.DS_Store

--- a/examples/pet-clinic-app/pom.xml
+++ b/examples/pet-clinic-app/pom.xml
@@ -27,9 +27,6 @@
     <webjars-bootstrap.version>5.3.3</webjars-bootstrap.version>
     <webjars-font-awesome.version>4.7.0</webjars-font-awesome.version>
 
-    <!-- AWS SDK version -->
-    <aws.sdk.version>2.31.39</aws.sdk.version>
-
     <checkstyle.version>10.18.1</checkstyle.version>
     <jacoco.version>0.8.12</jacoco.version>
     <libsass.version>0.2.29</libsass.version>
@@ -94,6 +91,11 @@
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.dsql</groupId>
+      <artifactId>aurora-dsql-jdbc-connector</artifactId>
+      <version>1.0.0</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.dsql</groupId>
@@ -166,37 +168,6 @@
       <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
 
-    <!-- AWS SDK dependencies -->
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>regions</artifactId>
-      <version>${aws.sdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>sts</artifactId>
-      <version>${aws.sdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>aws-core</artifactId>
-      <version>${aws.sdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>aws-json-protocol</artifactId>
-      <version>${aws.sdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>url-connection-client</artifactId>
-      <version>${aws.sdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>dsql</artifactId>
-      <version>${aws.sdk.version}</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/examples/pet-clinic-app/src/README.md
+++ b/examples/pet-clinic-app/src/README.md
@@ -2,7 +2,7 @@
 
 
 Below are the list of changes added :
-1. How to connect to DSQL with sample token generator code using DSQL libraries and a scheduled token refresh.
+1. How to connect to DSQL using the Aurora DSQL JDBC Connector for automatic IAM authentication.
 2. How to use UUID in place of IDENTITY as primary key. 
 3. A Retry Aspect sample class on how to retry on Errors/Exceptions. 
 4. A connection eviction override sample class on How to override connection eviction logic to handle DSQL supported/unsupported errors and exceptions.
@@ -58,18 +58,14 @@ There is no `Dockerfile` in this project. You can build a container image (if yo
 Our issue tracker is available [here](https://github.com/spring-projects/spring-petclinic/issues).
 
 ## Database configuration
-DsqlDataSourceConfig takes care of connecting the app with DSQL server based on application.properties file configurations.
-Provide the username, region, URL ands DSQL action into application.properties file as shown below with sample example.
+DsqlDataSourceConfig takes care of connecting the app with DSQL server based on application-dsql.properties file configurations.
+The Aurora DSQL JDBC Connector handles IAM authentication automatically.
 
 ```
-# Dsql DataSource Configuration
-# - Default region is us-east-1
-app.dsql.region=us-east-1
-# - Cluster endpoint format : jdbc:postgresql://<endpoint-url>/postgres?ssl=verify-full
-app.datasource.url=jdbc:postgresql://<cluster_dns>/postgres?ssl=verify-full
-# Update username for non-admin user here
+# Aurora DSQL JDBC Connector handles IAM authentication automatically
+app.datasource.url=jdbc:aws-dsql:postgresql://<cluster_endpoint>/postgres
 app.datasource.username=admin
-
+app.datasource.hikari.data-source-properties.ApplicationName=hibernate
 ```
 
 ## Test Applications

--- a/examples/pet-clinic-app/src/main/java/org/springframework/samples/petclinic/PetClinicApplication.java
+++ b/examples/pet-clinic-app/src/main/java/org/springframework/samples/petclinic/PetClinicApplication.java
@@ -19,7 +19,6 @@ package org.springframework.samples.petclinic;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ImportRuntimeHints;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * PetClinic Spring Boot Application.

--- a/examples/pet-clinic-app/src/main/java/org/springframework/samples/petclinic/config/DsqlDataSourceConfig.java
+++ b/examples/pet-clinic-app/src/main/java/org/springframework/samples/petclinic/config/DsqlDataSourceConfig.java
@@ -6,40 +6,18 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 import com.zaxxer.hikari.HikariDataSource;
 
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.dsql.DsqlUtilities;
-import software.amazon.awssdk.services.dsql.model.GenerateAuthTokenRequest;
-
-import java.util.function.Consumer;
-import java.time.Duration;
 import java.util.logging.Logger;
 
 @Configuration(proxyBeanMethods = false)
-@EnableScheduling
 public class DsqlDataSourceConfig {
 
 	final Logger logger = Logger.getLogger(this.toString());
 
-	@Value("${app.dsql.action:DB_CONNECT}")
-	private String action;
-
-	@Value("${app.dsql.region:US_EAST_1}")
-	private String region;
-
-	@Value("${app.dsql.token.refresh-rate:1800000}")
-	private long maxLifetime;
-
 	@Value("${app.datasource.username:admin}")
 	private String username;
-
-	private HikariDataSource dataSource;
 
 	@Bean
 	@Primary
@@ -51,8 +29,7 @@ public class DsqlDataSourceConfig {
 	@Bean
 	public HikariDataSource dataSource(DataSourceProperties properties) {
 		final HikariDataSource hds = properties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
-		hds.setMaxLifetime(maxLifetime);
-		this.dataSource = hds;
+		hds.setMaxLifetime(3300000); // 55 minutes (connector handles token refresh)
 		hds.setExceptionOverrideClassName(DsqlExceptionOverride.class.getName());
 
 		// Set the schema based on user type
@@ -61,34 +38,7 @@ public class DsqlDataSourceConfig {
 			logger.info("Set schema to myschema");
 		}
 
-		// set the password by generating token from credentials.
-		generateToken();
 		return hds;
-	}
-
-	@Scheduled(fixedRateString = "${app.dsql.token.refresh-interval:600000}")
-	public void generateToken() {
-		// Generate and set the DSQL token
-		logger.info("Region: " + region);
-		final DsqlUtilities utilities = DsqlUtilities.builder()
-			.region(Region.of(region.toLowerCase()))
-			.credentialsProvider(DefaultCredentialsProvider.create())
-			.build();
-
-		logger.info("Generating DSQL token for user:" + username);
-
-		final Consumer<GenerateAuthTokenRequest.Builder> requester = builder -> builder
-			.hostname(dataSource.getJdbcUrl().split("/")[2])
-			.region(Region.of(region))
-			.expiresIn(Duration.ofMillis(maxLifetime)); // Default is 900 seconds
-
-		// Use auth method according to the current user. The admin user is assumed to be
-		// "admin".
-		final String token = username.equals("admin") ? utilities.generateDbConnectAdminAuthToken(requester)
-				: utilities.generateDbConnectAuthToken(requester);
-
-		dataSource.setPassword(token);
-		logger.info("Generated DSQL token");
 	}
 
 }

--- a/examples/pet-clinic-app/src/main/resources/application-dsql.properties
+++ b/examples/pet-clinic-app/src/main/resources/application-dsql.properties
@@ -1,20 +1,11 @@
 database=dsql
 
-# Dsql DataSource Configuration
-# - Default region is us-east-1
-app.dsql.region=${REGION}
-
 spring.jpa.database-platform=software.amazon.dsql.hibernate.dialect.AuroraDSQLDialect
 
-# - By default, the client is connected to DSQL via sandbox
-# - Cluster endpoint format : jdbc:postgresql://<endpoint-url>/postgres?ssl=require
-app.datasource.url=jdbc:postgresql://${CLUSTER_ENDPOINT}/postgres?ssl=verify-full
+# Aurora DSQL JDBC Connector handles IAM authentication automatically
+app.datasource.url=jdbc:aws-dsql:postgresql://${CLUSTER_ENDPOINT}/postgres
 app.datasource.username=${CLUSTER_USER}
-
-# - Auth token refersh time in msec.
-app.dsql.token.refresh-rate=120000
-# - Auth token refersh interval in msec. Setting interval for 1 min to demonstrate refresh
-app.dsql.token.refresh-interval=60000
+app.datasource.hikari.data-source-properties.ApplicationName=hibernate
 
 # SQL is written to be idempotent so this is safe
 spring.sql.init.mode=always

--- a/examples/pet-clinic-app/src/test/java/org/springframework/samples/petclinic/DsqlIntegrationTest.java
+++ b/examples/pet-clinic-app/src/test/java/org/springframework/samples/petclinic/DsqlIntegrationTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.springframework.samples.petclinic;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Integration test for Aurora DSQL JDBC Connector.
+ *
+ * @author AWS
+ */
+@EnabledIfEnvironmentVariable(named = "RUN_INTEGRATION", matches = "TRUE")
+class DsqlIntegrationTest {
+
+	private static final String CLUSTER_ENDPOINT = System.getenv("CLUSTER_ENDPOINT");
+
+	private static final String CLUSTER_USER = System.getenv("CLUSTER_USER") != null ? System.getenv("CLUSTER_USER")
+			: "admin";
+
+	@BeforeAll
+	static void setUp() {
+		assertNotNull(CLUSTER_ENDPOINT, "CLUSTER_ENDPOINT environment variable must be set");
+	}
+
+	@Test
+	void testJdbcConnectorConnection() throws SQLException {
+		String url = "jdbc:aws-dsql:postgresql://" + CLUSTER_ENDPOINT + "/postgres?user=" + CLUSTER_USER;
+
+		try (Connection conn = DriverManager.getConnection(url)) {
+			assertNotNull(conn, "Connection should not be null");
+			assertFalse(conn.isClosed(), "Connection should be open");
+
+			try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery("SELECT 1 as test_value")) {
+				rs.next();
+				assertEquals(1, rs.getInt("test_value"));
+			}
+		}
+	}
+
+}

--- a/examples/pet-clinic-app/src/test/resources/application-test.properties
+++ b/examples/pet-clinic-app/src/test/resources/application-test.properties
@@ -15,6 +15,3 @@ spring.sql.init.mode=always
 
 # Ensure schema.sql is executed before Hibernate creates tables
 spring.jpa.defer-datasource-initialization=true
-
-# Disable the DSQL token refresh scheduler during tests
-app.dsql.token.refresh-rate=-1


### PR DESCRIPTION
Replace manual token generation with aurora-dsql-jdbc-connector which handles IAM authentication automatically.

## Changes
- Update JDBC URL to use `jdbc:aws-dsql:postgresql://` scheme
- Add `ApplicationName=hibernate` property for connection identification
- Remove `@EnableScheduling` and token generation code
- Remove AWS SDK dependencies (no longer needed with connector)
- Keep `maxLifetime` for HikariCP connection lifecycle management

## Benefits
- Simplified configuration - no manual token refresh scheduling
- Reduced dependencies - AWS SDK no longer needed directly
- Automatic IAM authentication handled by the connector
- Consistent with other ORM connector migrations